### PR TITLE
Replace Pack plugin info with link

### DIFF
--- a/eclipse/project/assign-device/index.html
+++ b/eclipse/project/assign-device/index.html
@@ -141,21 +141,9 @@
 
 <p>It is not possible to assign devices/boards to projects created by other plug-ins, because they lack the mechanisms to handle such additional data.</p>
 
-<h3 id="the-packs-plug-ins">The Packs plug-ins</h3>
+<h3 id="the-packs-plug-ins">The Packs plug-in</h3>
 
-<p>For the device list to be populated, it is required that the Packs plug-ins are first installed. To check this, use the <strong>About Eclipse</strong> menu and click the <strong>Installation Details</strong> button.</p>
-
-<p>
-<img src="/assets/images/2014/10/PacksFeature.png" alt="Check the presence of the Packs plug-ins" />
-</p>
-
-<p>If not present, it is recommended to first read the <a href="/plugins/packs-manager/">Packs manager</a> documentation page where installation details are also provided.</p>
-
-<h3 id="install-required-packs">Install required packs</h3>
-
-<p>Once the Packs plug-ins are available, and the list of available packages was retrieved, it is necessary to install the packages related to the devices used by the projects under development.</p>
-
-<p>Please note that failure to do so will prevent the device selection window to make the desired device available for selection.</p>
+<p>For the device list to be populated you must have the <a href="/plugins/packs-manager/">Packs plug-in installed</a> with at least one Pack installed.
 
 <h2 id="assign-device">Assign device</h2>
 


### PR DESCRIPTION
It wasn't clear (to me anyway) that the Packs needed to be downloaded and installed before I could associate a device with a project. The Pack plug-in installation page is very clear though so I have removed Pack plugin information from this page and linked to that one. Hope that's OK.