### PR TITLE
Adding packages which are required if starting from clean distribution

### DIFF
--- a/developer/build-binaries-prerequisites/index.html
+++ b/developer/build-binaries-prerequisites/index.html
@@ -221,7 +221,7 @@ Hello from Docker!
 
 <p>However, a very few of them might need to be installed explicitly. On Ubuntu the command is:</p>
 
-<div class="language-bash highlighter-rouge"><pre class="highlight"><code>sudo apt-get -y install curl git automake patch tar unzip
+<div class="language-bash highlighter-rouge"><pre class="highlight"><code>sudo apt-get -y install curl git automake patch tar unzip libtool texinfo pkg-config
 </code></pre>
 </div>
 


### PR DESCRIPTION
Not sure if these websites are autogenerated, but when I tried the installation from clean distribution (Ubuntu/xenial64) I was missing few packages. 